### PR TITLE
Add support for specifying a host to attach to when using nrepl.

### DIFF
--- a/src/clj/reply/eval_modes/nrepl.clj
+++ b/src/clj/reply/eval_modes/nrepl.clj
@@ -62,13 +62,18 @@
                        (pr-str read-result)))))))))
 
 (defn get-connection [options]
-  (let [port (if-let [attach-port (:attach options)]
+  (let [attach (:attach options)
+        [attach-port attach-host] (and attach
+                                       (reverse (.split attach ":")))
+        port (if attach-port
                (Integer/parseInt attach-port)
                (-> (nrepl.server/start-server :port (Integer/parseInt (or (:port options) "0")))
                    deref
                    :ss
-                   .getLocalPort))]
-    (nrepl/connect :host (or (:host options) "localhost") :port port)))
+                   .getLocalPort))
+        host (or attach-host
+                 (:host options "localhost"))]
+    (nrepl/connect :host host :port port)))
 
 (defn adhoc-eval [client form]
   (let [results (atom "nil")]

--- a/src/clj/reply/main.clj
+++ b/src/clj/reply/main.clj
@@ -84,7 +84,7 @@ See -main for descriptions."
   -e/--eval:           Provide custom code to evaluate in the user ns
   --skip-default-init: Skip the default initialization code
   --nrepl:             Launch nREPL (clojure.tools.nrepl) in interactive mode
-  --attach:            Attach to an existing nrepl session on this port, when used with --nrepl
+  --attach:            Attach to an existing nrepl session on this port or host:port, when used with --nrepl
   --port:              Start a new nrepl session on this port, when used with --nrepl
   --color:             Use color; currently only available with --nrepl"
   [& args]


### PR DESCRIPTION
reply currently assumes 'localhost' when you use the --attach option to connect
to nrepl. This commit adds support for connecting to a remote host via:

--attach host:port

'--attach port' still assumes localhost.
