### PR TITLE
Update clojuredocs client to 0.3.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -2,7 +2,7 @@
   :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojars.trptcolin/jline "2.7-alpha1"]
-                 [org.thnetos/cd-client "0.3.1" :exclusions [org.clojure/clojure]]
+                 [org.thnetos/cd-client "0.3.4"]
                  [clj-stacktrace "0.2.4"]
                  [clojure-complete "0.2.1" :exclusions [org.clojure/clojure]]
                  [org.clojure/tools.nrepl "0.2.0-beta1"]]


### PR DESCRIPTION
Hey Colin,

This tiny change updates cd-client to 0.3.4, which makes a number of changes:
- no longer need exclusions for clojure version
- newer clj-http that makes cheshire an optional dependency if desired
- newer cheshire/jackson version that will not interfere with clj-json in the same classloader
- offline support for cd-client, if desired
- slightly cleaner printed output for examples

I didn't make any changes to bring in any of the offline support stuff, not sure the best way to go about it (it requires downloading a snapshot), but at least the functionality is there.
