### PR TITLE
Make project.clj work with Leiningen 2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,6 @@ pom.xml
 *jar
 /lib/
 /classes/
+/target/
 .lein-failures
 .lein-deps-sum

--- a/project.clj
+++ b/project.clj
@@ -2,12 +2,15 @@
   :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojars.trptcolin/jline "2.7-alpha1"]
-                 [org.thnetos/cd-client "0.3.1" :exclusions [org.clojure/clojure]]
+                 [org.thnetos/cd-client "0.3.1"]
                  [clj-stacktrace "0.2.4"]
-                 [clojure-complete "0.2.1" :exclusions [org.clojure/clojure]]
-                 [org.clojure/tools.nrepl "0.2.0-beta1"]]
+                 [clojure-complete "0.2.1"]
+                 [org.clojure/tools.nrepl "0.2.0-beta4"]]
   :dev-dependencies [[midje "1.3-alpha4" :exclusions [org.clojure/clojure]]
                      [lein-midje "[1.0.0,)"]]
   :aot [reply.reader.jline.JlineInputReader]
   :source-path "src/clj"
-  :java-source-path "src/java")
+  :java-source-path "src/java"
+  :source-paths ["src/clj"]
+  :java-source-paths ["src/java"]
+  :main ^:skip-aot reply.main)


### PR DESCRIPTION
The :exclusions aren't necessary since cd-client and clojure-complete
both depend on the same version of Clojure as reply does.

Added a :main entry to make `lein run` a bit more convenient.
