### PR TITLE
Reply dotprofile support

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject reply "0.1.0-SNAPSHOT-clappehack"
+(defproject reply "0.1.0-SNAPSHOT-profilehack"
   :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojars.trptcolin/jline "2.7-alpha5"]

--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -3,8 +3,6 @@
             [clojure.repl])
   (:import (java.io File)))
 
-(declare eval-in-user-ns)
-
 (defmacro repl-defn [sym & args]
   (let [no-meta-source (binding [*print-meta* true]
                          (with-out-str (clojure.pprint/pprint `(defn ~sym ~@args))))
@@ -132,7 +130,7 @@
         (println "Unable to initialize completion.")))
 
     (in-ns '~'user)
-    (eval-in-user-ns (if (.exists (File. (str (System/getProperty "user.home") "/.reply_profile"))) (load-file (str (System/getProperty "user.home") "/.reply_profile"))))
+    (if (.exists (File. (str (System/getProperty "user.home") "/.reply_profile"))) (load-file (str (System/getProperty "user.home") "/.reply_profile")))
 
     (~'help)
     nil))


### PR DESCRIPTION
In response to Issue #58 I hacked in a quick and I think mostly sensible attempt at supporting it. I made it so reply will look for a .reply_profile file in the users home directory and use load-file to load the forms contained there. I've done some minimal testing and it's a fairly small change.
