### PR TITLE
added version number

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,5 +1,7 @@
-(defproject reply "0.1.0-SNAPSHOT"
-  :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
+(load-file "src/clj/version.clj")
+
+(defproject reply version/*reply-version*
+  :description "REPL-y: A fitter, happier, more productive REPL for Clojure." 
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [org.clojars.trptcolin/jline "2.7-alpha5"]
                  [org.thnetos/cd-client "0.3.4"]

--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -1,8 +1,7 @@
 (ns reply.initialization
   (:require [clojure.pprint]
-            [clojure.repl]))
-
-(def ^:dynamic *reply-version* "2.0.0-SNAPSHOT")
+            [clojure.repl]
+            [version]))
 
 (defmacro repl-defn [sym & args]
   (let [no-meta-source (binding [*print-meta* true]
@@ -92,7 +91,7 @@
   "Assumes cd-client will be on the classpath when this is evaluated."
   []
   `(do
-    (println "REPL-y" *reply-version*)
+    (println "REPL-y" version/*reply-version*)
     (println "Clojure" (clojure-version))
 
     (use '[clojure.repl :only ~'[source apropos dir]])


### PR DESCRIPTION
Added a version var to initialization.clj (is this the most logical place for it to exist?) and added it to the default-init-code to print like this (in line with the Clojure version number):

macbookair-michiel:bin Borkdude$ ./reply.sh 
REPL-y 2.0.0-SNAPSHOT
Clojure 1.3.0
    Exit: Control+D or (exit) or (quit)
Commands: (user/help)
    Docs: (doc function-name-here)
          (find-doc "part-of-name-here")
  Source: (source function-name-here)
          (user/sourcery function-name-here)
 Javadoc: (javadoc java-object-or-class-here)
Examples from clojuredocs.org: [clojuredocs or cdoc](user/clojuredocs name-here)
          (user/clojuredocs "ns-here" "name-here")
