### PR TITLE
Construct ConsoleReader using System/in and System/out 

### DIFF
--- a/src/clj/reply/reader/jline.clj
+++ b/src/clj/reply/reader/jline.clj
@@ -30,7 +30,7 @@
 (defn make-reader [options]
   (when (= "dumb" (System/getenv "TERM"))
     (.setProperty (Configuration/getProperties) "jline.terminal" "none"))
-  (let [reader (ConsoleReader.)
+  (let [reader (ConsoleReader. System/in System/out)
         history (FileHistory. (make-history-file (:history-file options)))
         completer (jline.completion/make-completer reply.initialization/eval-in-user-ns #())]
     (.setBlinkMatchingParen (.getKeys reader) true)


### PR DESCRIPTION
This allows reply to work with JVMs launched using flatland/decaf.
Otherwise, reply uses the original stdin, which is already closed.
