### PR TITLE
Fix '-e' and '-i' command line parameters

### DIFF
--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -153,9 +153,10 @@
 
 (defn construct-init-code
   [{:keys [skip-default-init
-           custom-init] :as options}]
+           custom-init custom-eval] :as options}]
   `(do
     ~(when-not skip-default-init (default-init-code))
-    ~(when custom-init custom-init)
+     ~(when custom-eval custom-eval)
+     ~(when custom-init custom-init)
     nil))
 

--- a/src/clj/reply/main.clj
+++ b/src/clj/reply/main.clj
@@ -14,8 +14,8 @@
 (defn parse-args [args]
   (cli/cli args
            ["-h" "--help" "Show this help screen" :flag true]
-           ["-e" "--eval" "Provide a custom form on the command line to evaluate in the user ns" :parse-fn read-string]
-           ["-i" "--init" "Provide a Clojure file to evaluate in the user ns" :parse-fn initialization/formify-file]
+           ["-e" "--eval" "--custom-eval" "Provide a custom form on the command line to evaluate in the user ns" :parse-fn read-string]
+           ["-i" "--init" "--custom-init" "Provide a Clojure file to evaluate in the user ns" :parse-fn initialization/formify-file]
            ["--standalone" "Launch standalone mode instead of the default nREPL" :flag true]
            ["--color" "Use color; currently only available with nREPL" :flag true]
            ["--skip-default-init" "Skip the default initialization code" :flag true]


### PR DESCRIPTION
Broken since using the tools.cli, as the options map expects a :custom-init but tools.cli map has :eval and :init.
Fixed by adding --custom-eval and --custom-init to the tools.cli options
