### PR TITLE
bump cd-client to 0.3.6

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
     :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
     :dependencies [[org.clojure/clojure "1.4.0"]
                    [jline/jline "2.8"]
-                   [org.thnetos/cd-client "0.3.5"]
+                   [org.thnetos/cd-client "0.3.6"]
                    [clj-stacktrace "0.2.4"]
                    [org.clojure/tools.nrepl "0.2.0-beta9"]
                    [org.clojure/tools.cli "0.2.1"]


### PR DESCRIPTION
cd-client 0.3.6 uses clj-http-lite instead of clj-http, removing all of the Apache dependencies.

New deps tree for cd-client looks like

```
∴ lein deps :tree
 [cheshire "4.0.3"]
   [com.fasterxml.jackson.core/jackson-core "2.0.6"]
   [com.fasterxml.jackson.dataformat/jackson-dataformat-smile "2.0.6"]
 [clj-http-lite "0.2.0"]
   [slingshot "0.10.3"]
```
