### PR TITLE
Don't try to catch ExceptionInfo on older versions of Clojure.

### DIFF
--- a/src/clj/reply/main.clj
+++ b/src/clj/reply/main.clj
@@ -36,12 +36,13 @@
                   clojure.repl/pst clj-stacktrace.repl/pst]
       (reader.jline/setup-reader! ~options)
       ~@body)
-    (catch clojure.lang.ExceptionInfo e#
-      (let [status# (:status (:object (ex-data e#)))
-            body# (:body (:object (ex-data e#)))]
-        (cond (= 401 status#) (println "Unauthorized.")
-              (number? status#) (println "Remote error:" (slurp body#))
-              :else (clojure.repl/pst e#))))
+    ~(if (resolve 'ex-info)
+       '(catch clojure.lang.ExceptionInfo e
+          (let [status# (:status (:object (ex-data e)))
+                body# (:body (:object (ex-data e)))]
+            (cond (= 401 status#) (println "Unauthorized.")
+                  (number? status#) (println "Remote error:" (slurp body))
+                  :else (clojure.repl/pst e)))))
     (catch Throwable t# (clojure.repl/pst t#))
     (finally (exit/exit))))
 


### PR DESCRIPTION
One of my earlier commits snuck in a dependency on 1.4 =(
