### PR TITLE
Option for a custom pretty printer

### DIFF
--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -92,7 +92,9 @@
 
 (defn default-init-code
   "Assumes cd-client will be on the classpath when this is evaluated."
-  []
+  [{:keys [require-pprint]
+    :or {:require-pprint '(require [clojure.pprint :refer (pp pprint)])}
+    :as options}]
   `(do
     (println "REPL-y" ~(version/get-version "reply" "reply"))
     (println "Clojure" (clojure-version))
@@ -103,7 +105,7 @@
       (refer 'clojure.repl :only '~'[pst doc find-doc]))
 
     (use '[clojure.java.javadoc :only ~'[javadoc]])
-    (use '[clojure.pprint :only ~'[pp pprint]])
+    ~require-pprint
 
     ~(export-definition 'reply.initialization/help)
 
@@ -155,7 +157,7 @@
   [{:keys [skip-default-init
            custom-init custom-eval] :as options}]
   `(do
-    ~(when-not skip-default-init (default-init-code))
+    ~(when-not skip-default-init (default-init-code options))
      ~(when custom-eval custom-eval)
      ~(when custom-init custom-init)
     nil))

--- a/src/clj/reply/main.clj
+++ b/src/clj/reply/main.clj
@@ -16,6 +16,7 @@
            ["-h" "--help" "Show this help screen" :flag true]
            ["-e" "--eval" "--custom-eval" "Provide a custom form on the command line to evaluate in the user ns" :parse-fn read-string]
            ["-i" "--init" "--custom-init" "Provide a Clojure file to evaluate in the user ns" :parse-fn initialization/formify-file]
+           ["--require-pprint" "Provide a custom form on the command line to require a pretty printer" :parse-fn read-string]
            ["--standalone" "Launch standalone mode instead of the default nREPL" :flag true]
            ["--color" "Use color; currently only available with nREPL" :flag true]
            ["--skip-default-init" "Skip the default initialization code" :flag true]


### PR DESCRIPTION
I wrote a [new pretty printer](https://github.com/brandonbloom/fipp) that I would love to install into `~/.lein/profile.clj`. Unfortunately, REPL-y's default initialization code seems to be all-or-nothing.

The attached patch does the brain dead bare minimum (afaict) to add a `:require-pprint` option. My goal is to make this work:

``` clojure
{:user {:repl-options {:require-pprint [bbloom.fipp.edn :refer (pprint)]}
        :dependencies [[fipp "0.1.0-SNAPSHOT"]]}}
```

I wrote this patch with blinders on to the rest of the REPLy codebase, so feel free to suggest a different approach.

On a slightly more ambitious note: Fipp might be fast enough to be used as a default printer in nREPL. I figure that I'll propose that change to Cemerick once I'm confident that I have a true drop-in replacement for `clojure.pprint`. I need to be using Fipp by default if there is any hope of it maturing to that point.
