### PR TITLE
Display a newline at the end of the exit message

### DIFF
--- a/spec/reply/integration_spec.clj
+++ b/spec/reply/integration_spec.clj
@@ -81,7 +81,8 @@
                             (.getBytes "exit\n(println 'foobar)\n"))
                           :output-stream @fake-out})
       (should-contain (with-out-str (initialization/help)) (str @fake-out))
-      (should-not-contain "foobar" (str @fake-out)))
+      (should-not-contain "foobar" (str @fake-out))
+      (should-contain "Bye for now!\n" (str @fake-out)))
 
     (it "allows using doc"
       (main/launch-nrepl {:attach (str *server-port*)

--- a/src/clj/reply/main.clj
+++ b/src/clj/reply/main.clj
@@ -45,7 +45,7 @@
   (println "Welcome back!"))
 
 (defn say-goodbye []
-  (print "Bye for now!")
+  (println "Bye for now!")
   (flush))
 
 (defmacro with-launching-context [options & body]


### PR DESCRIPTION
Without a newline, the "Bye for now!" message runs up against my bash prompt.  This commit fixes that by changing a "print" to a "println".
