### PR TITLE
Support sending nREPL a custom rendering function

### DIFF
--- a/src/clj/reply/eval_modes/nrepl.clj
+++ b/src/clj/reply/eval_modes/nrepl.clj
@@ -74,10 +74,8 @@
   (let [command-id (nrepl.misc/uuid)
         session (or (:session options) @current-session)
         session-sender (nrepl/client-session client :session session)
-        message-to-send (let [msg {:op "eval" :code form :id command-id}]
-                          (if-let [eval-options (:nrepl-interactive-eval-options options)]
-                            (merge eval-options msg)
-                            msg))
+        message-to-send (merge (get-in options [:nrepl-context :interactive-eval])
+                               {:op "eval" :code form :id command-id})
         read-input-line-fn (:read-input-line-fn options)]
     (session-sender message-to-send)
     (reset! current-command-id command-id)


### PR DESCRIPTION
Hi, over the past few days I've been hacking together [Puget](https://github.com/greglook/puget) and the Leiningen REPL to try to get pretty-printing enabled by default for REPL output. The result was [whidbey](https://github.com/greglook/whidbey), an nREPL middleware.

In the course of this, I needed to make a small change to REPLy to pass along some configuration to nREPL. What do you think of my implementation? I think I've got a grasp on how REPLy and nREPL interact, but if you have suggestions for a better way to do this I'd love to hear it.
