### PR TITLE
Standalone REPL: don't print a spurious newline after an exception

### DIFF
--- a/src/clj/reply/eval_modes/standalone.clj
+++ b/src/clj/reply/eval_modes/standalone.clj
@@ -39,8 +39,8 @@
     ;lazyseq: (1 2 3 4 5 ...)
     ;pr: "(1 2 3 4 5 ...)"
     (when (not= failure-sentinel result)
-      (print-value result))
-    (when (:interactive options) (println))
+      (print-value result)
+      (when (:interactive options) (println)))
     (eval-state/get-ns-string)))
 
 (defn run-repl [{:keys [prompt subsequent-prompt history-file


### PR DESCRIPTION
The output was originally:

```
user=> (/ 1 0)
#<ArithmeticException java.lang.ArithmeticException: Divide by zero>

user=>
```
