### PR TITLE
Standalone REPL: don't exit when printing throws an exception

### DIFF
--- a/spec/reply/integration_spec.clj
+++ b/spec/reply/integration_spec.clj
@@ -107,6 +107,15 @@
                                (.getBytes "424242\nmap\t\b\b\b(* 2 *1)\n"))
                              :output-stream @fake-out})
     (should-contain "848484" (str @fake-out)))
+
+  (it "does not crash when printing throws an exception"
+    (main/launch-standalone {:input-stream
+                             (java.io.ByteArrayInputStream.
+                               (.getBytes "(lazy-seq #())\n"))
+                             :output-stream @fake-out})
+    ; If we're not crashing, output should lack a full stack trace
+    ; that starts with clojure.lang.LazySeq.sval
+    (should-not-contain "LazySeq" (str @fake-out)))
   )
 
 (describe "nrepl integration" (tags :slow)

--- a/src/clj/reply/eval_modes/standalone.clj
+++ b/src/clj/reply/eval_modes/standalone.clj
@@ -26,21 +26,14 @@
 
 (defn execute [{:keys [value-to-string print-value print-out print-err] :as options}
                form]
-  (let [reply-read-eval (make-reply-read-eval options)
-        failure-sentinel (Object.)
-        result (if (empty? form)
-                 failure-sentinel
-                 (try (reply-read-eval form)
-                   (catch InterruptedException e nil)
-                   (catch Throwable t
-                     (let [e (clojure.main/repl-exception t)]
-                       ((or print-err print) e)
-                       (println))
-                     failure-sentinel)))]
-    ;lazyseq: (1 2 3 4 5 ...)
-    ;pr: "(1 2 3 4 5 ...)"
-    (when (not= failure-sentinel result)
-      (print-value (value-to-string result))
+  (let [reply-read-eval (make-reply-read-eval options)]
+    (when-not (empty? form)
+      (try
+        (print-value (value-to-string (reply-read-eval form)))
+        (catch InterruptedException e nil)
+        (catch Throwable t
+          (let [e (clojure.main/repl-exception t)]
+            ((or print-err print) e))))
       (when (:interactive options) (println)))
     (eval-state/get-ns-string)))
 


### PR DESCRIPTION
This fixes the standalone REPL to not crash when printing a value that throws an exception during printing, particularly common with lazy sequences:

```
user=> (take 10 (iterate #(* 2) 10))
ArityException Wrong number of args (1) passed to: user/eval5791/fn--5792
        clojure.core/iterate/fn--4307 (core.clj:2725)
        clojure.lang.LazySeq.sval (LazySeq.java:40)
        clojure.lang.LazySeq.seq (LazySeq.java:49)
        clojure.lang.RT.seq (RT.java:504)
        clojure.core/seq (core.clj:135)
        clojure.core/take/fn--4273 (core.clj:2628)
        clojure.lang.LazySeq.sval (LazySeq.java:40)
        clojure.lang.LazySeq.seq (LazySeq.java:49)
        clojure.lang.RT.seq (RT.java:504)
        clojure.core/seq (core.clj:135)
        clojure.core/map/fn--4248 (core.clj:2553)
        clojure.lang.LazySeq.sval (LazySeq.java:40)
Bye for now!
```

```
user=> (lazy-seq #())
IllegalArgumentException Don't know how to create ISeq from: user$eval5781$fn__5782$fn__5783
        clojure.lang.RT.seqFrom (RT.java:525)
        clojure.lang.RT.seq (RT.java:506)
        clojure.lang.LazySeq.seq (LazySeq.java:58)
        clojure.lang.LazySeq.equals (LazySeq.java:115)
        clojure.lang.LazySeq.equiv (LazySeq.java:100)
        clojure.lang.Util.pcequiv (Util.java:125)
        clojure.lang.Util.equiv (Util.java:32)
        clojure.core/not= (core.clj:786)
        reply.eval-modes.standalone/execute (standalone.clj:42)
        clojure.core/apply (core.clj:628)
        clojure.core/partial/fn--4231 (core.clj:2470)
        clojure.core/map/fn--4248 (core.clj:2561)
Bye for now!
```
