### PR TITLE
[Fix #151] Display JVM and nREPL version information on start

### DIFF
--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -2,11 +2,13 @@
   (:require [clojure.pprint]
             [clojure.repl]
             [clojure.main]
+            [clojure.tools.nrepl :only [version]]
             [trptcolin.versioneer.core :as version]))
 
 (def prelude
-  `[(println "REPL-y" ~(version/get-version "reply" "reply"))
-    (println "Clojure" (clojure-version))])
+  `[(println (str "REPL-y " ~(version/get-version "reply" "reply") ", nREPL " (:version-string clojure.tools.nrepl/version)))
+    (println "Clojure" (clojure-version))
+    (println (System/getProperty "java.vm.name") (System/getProperty "java.runtime.version"))])
 
 (defn help
   "Prints a list of helpful commands."


### PR DESCRIPTION
After the changes we have:

```
REPL-y 0.3.2-SNAPSHOT, nREPL 0.2.3
Clojure 1.4.0
Java HotSpot(TM) 64-Bit Server VM 1.7.0_17-b02
        Exit: Control+D or (exit) or (quit)
    Commands: (user/help)
        Docs: (doc function-name-here)
              (find-doc "part-of-name-here")
Find by Name: (find-name "part-of-name-here")
      Source: (source function-name-here)
     Javadoc: (javadoc java-object-or-class-here)
    Examples from clojuredocs.org: [clojuredocs or cdoc]
              (user/clojuredocs name-here)
              (user/clojuredocs "ns-here" "name-here")
user=>
```
