### PR TITLE
Fix a couple of problems found via Eastwood lint tool

### DIFF
--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -2,7 +2,7 @@
   (:require [clojure.pprint]
             [clojure.repl]
             [clojure.main]
-            [clojure.tools.nrepl :only [version]]
+            [clojure.tools.nrepl :refer [version]]
             [trptcolin.versioneer.core :as version]))
 
 (def prelude

--- a/src/clj/reply/main.clj
+++ b/src/clj/reply/main.clj
@@ -69,11 +69,12 @@
                '(catch Throwable t# (clojure.repl/pst t#))])
     (finally (say-goodbye))))
 
-(defn launch-nrepl [options]
+(defn launch-nrepl
   "Launches the nREPL version of REPL-y, with options already parsed out. The
   options map can also include :input-stream and :output-stream entries, which
   must be Java objects passed via this entry point, as they can't be parsed
   from a command line."
+  [options]
   (with-launching-context options
     (eval-modes.nrepl/main options)))
 


### PR DESCRIPTION
In an ns :require, :only does nothing (it is useful for :use).  :refer
should be used with :require to refer symbols.

Function launch-nrepl had its doc string in the wrong place.
