### PR TITLE
Bump jline2 version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: clojure
-lein: lein2
-script: "lein2 do compile, spec"
+lein: lein
+script: "lein do compile, spec"
 jdk:
   - openjdk6
   - openjdk7
   - oraclejdk7
+  - oraclejdk8

--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   (defproject reply "0.3.8-SNAPSHOT"
     :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
     :dependencies [[org.clojure/clojure "1.4.0"]
-                   [jline "2.12.1"]
+                   [jline "2.14.5"]
                    [org.thnetos/cd-client "0.3.6"]
                    [clj-stacktrace "0.2.7"]
                    [org.clojure/tools.nrepl "0.2.8"]


### PR DESCRIPTION
closes #173

I'm not sure what your acceptance standards beyond the `lein do compile, spec` in the repo's `.travis.yml` (which succeeded locally for me), but I was able to confirm that with this version bump, running the code locally with `lein trampoline run` yielded a REPL that honored my `~/.inputrc`'s custom vi keybindings.