### PR TITLE
Add JDK 9 to travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ jdk:
   - openjdk7
   - oraclejdk7
   - oraclejdk8
+  - oraclejdk9


### PR DESCRIPTION
Since the issue (https://github.com/trptcolin/reply/issues/177) on JDK 9 is fixed it will be good to add JDK 9 to Travis CI. I have tested it locally with master and tests pass.