### PR TITLE
Defer the loading of reply.parsing namespace for faster startup

### DIFF
--- a/src/clj/reply/eval_modes/shared.clj
+++ b/src/clj/reply/eval_modes/shared.clj
@@ -33,3 +33,13 @@
                            {:no-jline true
                             :prompt-string ""})))]
     options))
+
+(defn load-parsed-forms-fn-in-background
+  "Loading of reply.parsing namespace takes a lot of time. We can do it in
+  background while the user is typing their first form, that way user spends
+  less time waiting.
+
+  Return the future that delivers `reply.parsing/parsed-forms` function."
+  []
+  (future (require 'reply.parsing)
+          (resolve 'reply.parsing/parsed-forms)))

--- a/src/clj/reply/parsing.clj
+++ b/src/clj/reply/parsing.clj
@@ -56,12 +56,13 @@
   - prompt-string: for customizing the prompt
   - text-so-far: mostly useful in the recursion
   And returns a seq of *strings* representing complete forms."
-  [{:keys [request-exit text-so-far read-line-fn] :as options}]
-  (if-let [next-text (read-line-fn options)]
+  ([options]
+   (parsed-forms ((:read-line-fn options) options) options))
+  ([next-text {:keys [request-exit text-so-far] :as options}]
+   (if next-text
      (let [interrupted? (= :interrupted next-text)
            parse-tree (when-not interrupted? (reparse text-so-far next-text))]
        (if (or interrupted? (empty? (:content parse-tree)))
          (list "")
          (process-parse-tree parse-tree options)))
-     (list request-exit)))
-
+     (list request-exit))))


### PR DESCRIPTION
While I was working on the [blogpost about long Clojure start times](http://clojure-goes-fast.com/blog/clojures-slow-start/) I noticed that REPLy (which is used by Leiningen and Boot both) eats up a considerable percentage of total load time.

In particular, `reply.parsing` namespace, which transitively loads sjacket and other libraries, stood very distinctively. I saw it as an opportunity to defer the loading of this namespace until the user enters their very first form into the REPL. This pull request makes `reply.parsing` be loaded in background to wait less.

After the patch, I got a consistent ~2 seconds improvement when loading `reply.main`. E.g.:

```clojure
;; 0.3.8
user=> (time (require 'reply.main))
"Elapsed time: 4082.037985 msecs"

;; Patched
user=> (time (require 'reply.main))
"Elapsed time: 2170.414554 msecs"
```