### PR TITLE
[Fix #181] Update to nREPL 0.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ me know if you are!
 ## Thanks
 
 Thanks to the developers of [Clojure](https://github.com/clojure/clojure),
-[JLine](https://github.com/jline/jline2), [nREPL](https://github.com/clojure/tools.nrepl),
+[JLine](https://github.com/jline/jline2), [nREPL](https://github.com/nrepl/nrepl),
 [clojure-complete](https://github.com/ninjudd/clojure-complete),
 [ClojureDocs](http://clojuredocs.org), and [clojuredocs-client](https://github.com/dakrone/clojuredocs-client),
 for their work on the excellent projects that this project depends upon.

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                    [jline "2.14.5"]
                    [org.thnetos/cd-client "0.3.6"]
                    [clj-stacktrace "0.2.7"]
-                   [org.clojure/tools.nrepl "0.2.13"]
+                   [nrepl "0.4.0"]
                    [org.clojure/tools.cli "0.3.1"]
                    [com.cemerick/drawbridge "0.0.6"
                     :exclusions [org.clojure/tools.nrepl]]

--- a/project.clj
+++ b/project.clj
@@ -9,8 +9,7 @@
                    [clj-stacktrace "0.2.7"]
                    [nrepl "0.4.0"]
                    [org.clojure/tools.cli "0.3.1"]
-                   [com.cemerick/drawbridge "0.0.6"
-                    :exclusions [org.clojure/tools.nrepl]]
+                   [nrepl/drawbridge "0.1.0"]
                    [trptcolin/versioneer "0.1.1"]
                    [clojure-complete "0.2.5"]
                    [org.clojars.trptcolin/sjacket "0.1.1.1"

--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                    [jline "2.14.5"]
                    [org.thnetos/cd-client "0.3.6"]
                    [clj-stacktrace "0.2.7"]
-                   [nrepl "0.4.0"]
+                   [nrepl "0.4.1"]
                    [org.clojure/tools.cli "0.3.1"]
                    [nrepl/drawbridge "0.1.0"]
                    [trptcolin/versioneer "0.1.1"]

--- a/spec/reply/integration_spec.clj
+++ b/spec/reply/integration_spec.clj
@@ -18,8 +18,8 @@
 ;; TODO: this is easy but seems like wasted effort
 ;;       probably better to use pomegranate
 (def nrepl
-  {:local-path "spec/nrepl-0.4.0.jar"
-   :remote-url "https://clojars.org/repo/nrepl/nrepl/0.4.0/nrepl-0.4.0.jar"})
+  {:local-path "spec/nrepl-0.4.1.jar"
+   :remote-url "https://clojars.org/repo/nrepl/nrepl/0.4.1/nrepl-0.4.1.jar"})
 
 (def logging
   {:local-path "spec/tools.logging-0.4.1.jar"

--- a/src/clj/reply/eval_modes/nrepl.clj
+++ b/src/clj/reply/eval_modes/nrepl.clj
@@ -2,10 +2,10 @@
   (:import [java.util.concurrent LinkedBlockingQueue TimeUnit]
            [java.net ServerSocket])
   (:require [clojure.main]
-            [clojure.tools.nrepl :as nrepl]
-            [clojure.tools.nrepl.misc :as nrepl.misc]
-            [clojure.tools.nrepl.server :as nrepl.server]
-            [clojure.tools.nrepl.transport :as nrepl.transport]
+            [nrepl.core :as nrepl]
+            [nrepl.misc :as nrepl.misc]
+            [nrepl.server :as nrepl.server]
+            [nrepl.transport :as nrepl.transport]
             [reply.exit]
             [reply.eval-modes.shared :as eval-modes.shared]
             [reply.eval-state :as eval-state]
@@ -235,4 +235,3 @@
       (run-repl client options)
       (reset-nrepl-state!)
       (simple-jline/shutdown))))
-

--- a/src/clj/reply/eval_modes/nrepl.clj
+++ b/src/clj/reply/eval_modes/nrepl.clj
@@ -150,7 +150,7 @@
    registered) if it's available."
   []
   (try
-    (require '[cemerick.drawbridge.client])
+    (require '[drawbridge.client])
     (catch Exception e)))
 
 (defn get-connection [{:keys [attach host port]}]

--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -2,11 +2,11 @@
   (:require [clojure.pprint]
             [clojure.repl]
             [clojure.main]
-            [clojure.tools.nrepl]
+            [nrepl.core]
             [trptcolin.versioneer.core :as version]))
 
 (def prelude
-  `[(println (str "REPL-y " ~(version/get-version "reply" "reply") ", nREPL " (:version-string clojure.tools.nrepl/version)))
+  `[(println (str "REPL-y " ~(version/get-version "reply" "reply") ", nREPL " (:version-string nrepl.core/version)))
     (println "Clojure" (clojure-version))
     (println (System/getProperty "java.vm.name") (System/getProperty "java.runtime.version"))])
 
@@ -228,4 +228,3 @@
      ~(when custom-eval custom-eval)
      ~(when custom-init custom-init)
     nil))
-


### PR DESCRIPTION
Here's the discussed migration to nREPL 0.4. As you can see the changes are few and trivial. The only real problem is the dependency to drawbridge, which I didn't expect.

I've pinged @cemerick about it https://github.com/cemerick/drawbridge/issues/23