### PR TITLE
Fix completion-eval to not bind to namespaces that don't exist.

### DIFF
--- a/src/clj/reply/eval_modes/nrepl.clj
+++ b/src/clj/reply/eval_modes/nrepl.clj
@@ -173,7 +173,9 @@
        :session session}
       (binding [*print-length* nil
                 *print-level* nil]
-        (pr-str `(binding [*ns* (the-ns (symbol ~(deref current-ns)))] ~form))))
+        (pr-str `(binding [*ns* (or (find-ns (symbol ~(deref current-ns)))
+                                    *ns*)]
+                   ~form))))
     (read-string @results)))
 
 (defn poll-for-responses [{:keys [print-out print-err] :as options} connection]


### PR DESCRIPTION
The `reply.eval-modes.nrepl/completion-eval` function would attempt to
bind `*ns*` to the value inside `current-ns`, which starts out as
`reply.eval-modes.nrepl`, a namespace that exists on the client but
usually doesn't exist on the server.

This patch changes it so that it falls back to the current value of
`*ns*` if the namespace in question doesn't exist.

Fixes technomancy/leiningen#2465