### PR TITLE
Fix exception when attaching to tools.nrepl remote nREPL

### DIFF
--- a/src/clj/reply/initialization.clj
+++ b/src/clj/reply/initialization.clj
@@ -6,7 +6,7 @@
             [trptcolin.versioneer.core :as version]))
 
 (def prelude
-  `[(println (str "REPL-y " ~(version/get-version "reply" "reply") ", nREPL " (:version-string nrepl.core/version)))
+  `[(println (str "REPL-y " ~(version/get-version "reply" "reply") ", nREPL " ~(:version-string nrepl.core/version)))
     (println "Clojure" (clojure-version))
     (println (System/getProperty "java.vm.name") (System/getProperty "java.runtime.version"))])
 


### PR DESCRIPTION
If I try to connect to a remote nREPL that uses the old tools.nrepl instead of the new nrepl, I get the following exception:

```
$ java -jar target/reply-0.4.4-SNAPSHOT-standalone.jar --attach localhost:6000
CompilerException java.lang.ClassNotFoundException: nrepl.core, compiling:(/tmp/form-init5773107386382421609.clj:1:91)
#object[clojure.lang.Namespace 0x5dc2b378 "user"]
Error loading namespace; falling back to user
nil
user=>
```

This PR fixes the exception by resolving the nREPL version locally instead of in the remote repl.