### PR TITLE
ClassCastException when passing --port option

### DIFF
--- a/src/clj/reply/eval_modes/nrepl.clj
+++ b/src/clj/reply/eval_modes/nrepl.clj
@@ -156,7 +156,9 @@
 (defn get-connection [{:keys [attach host port scheme]
                        :or {scheme "nrepl"}}]
   (let [server (when-not attach
-                 (nrepl.server/start-server :port port))
+                 (nrepl.server/start-server
+                   :port (when port
+                           (-> port str Integer/parseInt))))
         port (when-not attach
                (:port server))
         url (url-for attach host port scheme)]


### PR DESCRIPTION
Commit 7fe67e4e2eb5580e42da6662fd05cd4c62a6533c introduced a regression where REPL-y will throw an exception when it gets passed the `--port` command-line argument. The exception is easily reproducible with the command

    clojure -Sdeps '{:deps {reply {:mvn/version "0.4.3"}}}' -m reply.main --port 3333

This breaks clients of the REPL-y command-line API such as Leiningen, see technomancy/leiningen#2572.

The proposed change restores the previous behaviour as faithfully as possible. `reply.eval-modes.nrepl/main` will again accept both string and integer for `:port`.