### PR TITLE
Allow keyword completion

### DIFF
--- a/spec/reply/completion_spec.clj
+++ b/spec/reply/completion_spec.clj
@@ -16,10 +16,14 @@
     (should= "map" (get-word-ending-at "map" 3))
     (should= "map" (get-word-ending-at "(map first [0 1 2])" 4)))
 
-  (it "finds namespaces, also as symbols or keywords"
+  (it "finds namespaces, also as symbols"
     (should= "clojure.c" (get-word-ending-at "clojure.c" 9))
-    (should= "clojure.c" (get-word-ending-at "'clojure.c" 10))
-    (should= "clojure.c" (get-word-ending-at ":clojure.c" 10)))
+    (should= "clojure.c" (get-word-ending-at "'clojure.c" 10)))
+
+  (it "finds keywords"
+    (should= ":clojure.c" (get-word-ending-at ":clojure.c" 10))
+    (should= ":ke" (get-word-ending-at ":keyword" 3))
+    (should= "::foobar" (get-word-ending-at "::foobar" 8)))
 
   (it "omits brackets of several sorts (but takes asterisks)"
     (should= "*foo" (get-word-ending-at "(*foo" 5))

--- a/src/clj/reply/completion.clj
+++ b/src/clj/reply/completion.clj
@@ -30,6 +30,5 @@
   (let [input-start (input-up-to input index)
         last-word (or (last-word input-start) "")]
     (if (re-seq (re-pattern word-pattern-string) last-word)
-      (str/replace last-word #"[':]" "")
+      (str/replace last-word #"[']" "")
       "")))
-


### PR DESCRIPTION
While working on #205, I've noticed that REPLy was converting keywords into symbols, which is no longer a good idea now that incomplete supports keyword completion. I guess that's a pretty straightforward change. 