### PR TITLE
[Fix #204] Remove clojuredocs integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ A fitter, happier, more productive REPL for Clojure.
   - Clojure namespace-qualified vars
   - Java classes, packages
   - Java package-qualified classes, static methods
-- ClojureDocs support via a `clojuredocs` command
 - Optional nREPL integration
 
 ## Installation
@@ -102,7 +101,6 @@ me know if you are!
 Thanks to the developers of [Clojure](https://github.com/clojure/clojure),
 [JLine](https://github.com/jline/jline2), [nREPL](https://github.com/nrepl/nrepl),
 [incomplete](https://github.com/nrepl/incomplete),
-[ClojureDocs](http://clojuredocs.org), and [clojuredocs-client](https://github.com/dakrone/clojuredocs-client),
 for their work on the excellent projects that this project depends upon.
 
 Special thanks to [8th Light](http://8thlight.com) for allowing me to work on

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,6 @@
     :description "REPL-y: A fitter, happier, more productive REPL for Clojure."
     :dependencies [[org.clojure/clojure "1.7.0"]
                    [jline "2.14.6"]
-                   [org.thnetos/cd-client "0.3.6"]
                    [clj-stacktrace "0.2.8"]
                    [nrepl "0.8.3"]
                    ;; tools.cli 1.0 requires Clojure 1.8


### PR DESCRIPTION
It has been broken for years, so let's just remove all this
dead code.

Btw, what's is this `export-definition` abstraction about? In the absence of documentation for the function I couldn't quite figure it out. 