### PR TITLE
Modernize source now that we target Clojure 1.8

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -14,7 +14,6 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :url "https://github.com/trptcolin/reply"
   :profiles {:dev {:dependencies [[classlojure "0.6.6"]]}
-             :base {:dependencies []}
              ;; Clojure versions matrix
              :provided {:dependencies [[org.clojure/clojure "1.12.4"]]}
              :1.8 {:dependencies [[org.clojure/clojure "1.8.0"]]}

--- a/src/reply/eval_modes/standalone/concurrency.clj
+++ b/src/reply/eval_modes/standalone/concurrency.clj
@@ -23,7 +23,7 @@
           (throw e))))))
 
 (defn stop [action & {:keys [hard-kill-allowed]}]
-  (let [thread (:thread @action)]
+  (let [^Thread thread (:thread @action)]
     (when thread (.interrupt thread))
     (when hard-kill-allowed
       (when (and @action (not (:completed @action)) (.isAlive thread))

--- a/src/reply/main.clj
+++ b/src/reply/main.clj
@@ -57,16 +57,13 @@
     (with-redefs [clojure.core/print-sequential hacks.printing/print-sequential
                   clojure.repl/pst clj-stacktrace.repl/pst]
       ~@body)
-    ~@(filter identity
-              [(when (resolve 'ex-info)
-                 `(catch clojure.lang.ExceptionInfo e#
-                    (let [status# (:status (:object (ex-data e#)))
-                          body# (:body (:object (ex-data e#)))]
-                      (cond (= 401 status#) (println "Unauthorized.")
-                            (number? status#) (println "Remote error:"
-                                                       (slurp ~body))
-                            :else (clojure.repl/pst e#)))))
-               '(catch Throwable t# (clojure.repl/pst t#))])
+    (catch clojure.lang.ExceptionInfo e#
+      (let [status# (:status (:object (ex-data e#)))
+            body# (:body (:object (ex-data e#)))]
+        (cond (= 401 status#) (println "Unauthorized.")
+              (number? status#) (println "Remote error:" (slurp body#))
+              :else (clojure.repl/pst e#))))
+    (catch Throwable t# (clojure.repl/pst t#))
     (finally (say-goodbye))))
 
 (defn launch-nrepl

--- a/src/reply/parsing.clj
+++ b/src/reply/parsing.clj
@@ -91,7 +91,7 @@
                (str text-so-far \newline next-text)
                next-text)
         [form-strings remainder] (read-forms text)]
-    (if (and remainder (not (.isEmpty remainder)))
+    (if (seq remainder)
       (lazy-seq
         (concat form-strings
                 (parsed-forms

--- a/src/reply/reader/simple_jline.clj
+++ b/src/reply/reader/simple_jline.clj
@@ -15,7 +15,7 @@
 
 (def ^:private default-history-size-value 500)
 
-(defn- make-history-file [^String history-path]
+(defn- make-history-file ^File [^String history-path]
   (if history-path
     (let [history-file (File. history-path)]
       (if (.getParentFile history-file)
@@ -40,7 +40,7 @@
   [^File history-file]
   (when (.exists history-file)
     (try
-      (let [first-line (with-open [rdr (clojure.java.io/reader history-file)]
+      (let [first-line (with-open [^BufferedReader rdr (clojure.java.io/reader history-file)]
                          (.readLine rdr))]
         (when (and first-line
                    (not (re-find #"^\d+:" first-line)))
@@ -70,6 +70,7 @@
     (flush-history (.getHistory reader))))
 
 (defn setup-console-reader
+  ^LineReader
   [{:keys [prompt-string reader input-stream output-stream
            history-file completer-factory blink-parens]
     :or {prompt-string "=> "
@@ -139,7 +140,7 @@
     (do
       (shutdown state)
       (let [reader (setup-console-reader state)
-            prompt (or (:prompt-string state) "=> ")
+            ^String prompt (or (:prompt-string state) "=> ")
             input (try (.readLine reader prompt)
                     (catch UserInterruptException e
                       :interrupted)


### PR DESCRIPTION
Some follow-up cleanup now that the floor is Clojure 1.8 and the deps are all current.

- Drops the `(resolve 'ex-info)` guard in the launch macro (ex-info has been around since 1.4) and fixes a latent bug in the same block where the remote-error branch slurped the macro's body form instead of the response body.
- Adds type hints to clear all the reflection warnings `lein check` was emitting.
- Removes the redundant empty `:base` profile.

Tests stay green and `lein check` is now warning-free.